### PR TITLE
style(article): avoid horizontal overflow on mobile screens

### DIFF
--- a/src/articles/2.js
+++ b/src/articles/2.js
@@ -1,4 +1,12 @@
 export const leCommencement = `
+<style>
+  p > img {
+    width: 100%;
+    max-height: 20em;
+    object-fit: contain;
+  }
+</style>
+
 # Le commencement
 
 Quoi de mieux pour commencer, que de commencer par le commencement ? 


### PR DESCRIPTION
Just a little contribution @gabbloquet to avoid horizontal overflow on mobile screens.

## Before

![image](https://user-images.githubusercontent.com/9600228/147512421-3289fddc-b628-4764-8a25-4d0e0b5f224d.png)

## After

![Capture d’écran 2021-12-28 à 00 01 04](https://user-images.githubusercontent.com/9600228/147512455-521c7c73-f156-467a-afc1-3fa17d7b7672.png)

Unfortunately, I cannot make this work for all your articles with `blog.css` because your markdown is not preprocessed, so the CSS is not applied to its content.

Feel free if you have question and congrats for this blog :-)